### PR TITLE
fix display of panels that use the bufferedcanvas

### DIFF
--- a/graph.py
+++ b/graph.py
@@ -28,9 +28,7 @@ class Graph(BufferedCanvas):
         style = style | wx.NO_FULL_REPAINT_ON_RESIZE
         #call super function
         #super(Graph, self).__init__(parent, id, pos, size, style)
-        BufferedCanvas.__init__(self, parent, id)
-
-        self.SetSize(wx.Size(170, 100))
+        BufferedCanvas.__init__(self, parent, id, wx.DefaultPosition, wx.Size(170, 100))
 
         self.extruder0temps       = [0]
         self.extruder0targettemps = [0]

--- a/gviz.py
+++ b/gviz.py
@@ -215,8 +215,12 @@ class gviz(wx.Panel):
         
     def resize(self,event):
         size=self.GetClientSize()
+	if size[0]==0:
+	    size[0]=1
+	if size[1]==0:
+	    size[1]=1
         newsize=min(float(size[0])/self.size[0],float(size[1])/self.size[1])
-        self.size=self.GetClientSize()
+        self.size=size
         wx.CallAfter(self.zoom,0,0,newsize)
         
 

--- a/xybuttons.py
+++ b/xybuttons.py
@@ -58,8 +58,7 @@ class XYButtons(BufferedCanvas):
         self.cornerCallback = cornerCallback
         self.enabled = False
     
-        BufferedCanvas.__init__(self, parent, ID)
-        self.SetSize(self.bg_bmp.GetSize())
+        BufferedCanvas.__init__(self, parent, ID, wx.DefaultPosition, self.bg_bmp.GetSize())
 
         # Set up mouse and keyboard event capture
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)

--- a/zbuttons.py
+++ b/zbuttons.py
@@ -47,9 +47,7 @@ class ZButtons(BufferedCanvas):
         self.moveCallback = moveCallback
         self.enabled = False
 
-        BufferedCanvas.__init__(self, parent, ID)
-
-        self.SetSize(wx.Size(59, 244))
+        BufferedCanvas.__init__(self, parent, ID, wx.DefaultPosition, self.bg_bmp.GetSize())
 
         # Set up mouse and keyboard event capture
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)


### PR DESCRIPTION
- seems to be important to set the size in the **init** of
  the BufferedCanvas.
- also fixed a division by zero (and not painting the grid)
  in resize method of gviz.py
