### PR TITLE
Fix for build size setting in .pronsolerc

### DIFF
--- a/pronterface/printrun/graph.py
+++ b/pronterface/printrun/graph.py
@@ -28,9 +28,7 @@ class Graph(BufferedCanvas):
         style = style | wx.NO_FULL_REPAINT_ON_RESIZE
         #call super function
         #super(Graph, self).__init__(parent, id, pos, size, style)
-        BufferedCanvas.__init__(self, parent, id)
-
-        self.SetSize(wx.Size(150, 80))
+        BufferedCanvas.__init__(self, parent, id, wx.DefaultPosition, wx.Size(150, 80))
 
         self.extruder0temps       = [0]
         self.extruder0targettemps = [0]

--- a/pronterface/printrun/xybuttons.py
+++ b/pronterface/printrun/xybuttons.py
@@ -61,8 +61,7 @@ class XYButtons(BufferedCanvas):
         self.bgcolor.SetFromName(bgcolor)
         self.bgcolormask = wx.Colour(self.bgcolor.Red(), self.bgcolor.Green(), self.bgcolor.Blue(), 128)
 
-        BufferedCanvas.__init__(self, parent, ID)
-        self.SetSize(self.bg_bmp.GetSize())
+        BufferedCanvas.__init__(self, parent, ID, wx.DefaultPosition, self.bg_bmp.GetSize())
 
         # Set up mouse and keyboard event capture
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)

--- a/pronterface/printrun/zbuttons.py
+++ b/pronterface/printrun/zbuttons.py
@@ -46,9 +46,7 @@ class ZButtons(BufferedCanvas):
         self.bgcolor.SetFromName(bgcolor)
         self.bgcolormask = wx.Colour(self.bgcolor.Red(), self.bgcolor.Green(), self.bgcolor.Blue(), 128)
 
-        BufferedCanvas.__init__(self, parent, ID)
-
-        self.SetSize(wx.Size(59, 244))
+        BufferedCanvas.__init__(self, parent, ID, wx.DefaultPosition, self.bg_bmp.GetSize())
 
         # Set up mouse and keyboard event capture
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)


### PR DESCRIPTION
The bed_size_x/y variables in .pronsolerc where unused and
caused a warning at startup. This sets build_dimensions
instead to the default value as this is the variable you
need to adapt when your printer has a bigger build area.

The bed_size variables were really misleading for me: I adapted them to the bed size of the Mendel, but nothing happened. I used the pronterface with the wrong bedsize for quite a while before I found out what setting I really had to change in my ~/.pronsolerc. I now use

```
set build_dimensions 200x200x94
```

and it works like a charm :-)
