### PR TITLE
fix display of panels that use the bufferedcanvas (again)

### DIFF
--- a/pronterface/printrun/graph.py
+++ b/pronterface/printrun/graph.py
@@ -28,9 +28,7 @@ class Graph(BufferedCanvas):
         style = style | wx.NO_FULL_REPAINT_ON_RESIZE
         #call super function
         #super(Graph, self).__init__(parent, id, pos, size, style)
-        BufferedCanvas.__init__(self, parent, id)
-
-        self.SetSize(wx.Size(150, 80))
+        BufferedCanvas.__init__(self, parent, id, wx.DefaultPosition, wx.Size(150, 80))
 
         self.extruder0temps       = [0]
         self.extruder0targettemps = [0]

--- a/pronterface/printrun/xybuttons.py
+++ b/pronterface/printrun/xybuttons.py
@@ -61,8 +61,7 @@ class XYButtons(BufferedCanvas):
         self.bgcolor.SetFromName(bgcolor)
         self.bgcolormask = wx.Colour(self.bgcolor.Red(), self.bgcolor.Green(), self.bgcolor.Blue(), 128)
 
-        BufferedCanvas.__init__(self, parent, ID)
-        self.SetSize(self.bg_bmp.GetSize())
+        BufferedCanvas.__init__(self, parent, ID, wx.DefaultPosition, self.bg_bmp.GetSize())
 
         # Set up mouse and keyboard event capture
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)

--- a/pronterface/printrun/zbuttons.py
+++ b/pronterface/printrun/zbuttons.py
@@ -46,9 +46,7 @@ class ZButtons(BufferedCanvas):
         self.bgcolor.SetFromName(bgcolor)
         self.bgcolormask = wx.Colour(self.bgcolor.Red(), self.bgcolor.Green(), self.bgcolor.Blue(), 128)
 
-        BufferedCanvas.__init__(self, parent, ID)
-
-        self.SetSize(wx.Size(59, 244))
+        BufferedCanvas.__init__(self, parent, ID, wx.DefaultPosition, self.bg_bmp.GetSize())
 
         # Set up mouse and keyboard event capture
         self.Bind(wx.EVT_LEFT_DOWN, self.OnLeftDown)


### PR DESCRIPTION
Re-applying my commit b232bb89898da0acff2b97bd460b801cbace1019
It has been undone by c17bc11169522d6d38436f84fd08baa79e914480
As the later commit had the title 'Slic3r integrated for
Ubuntu 64bit', I don't think this was by intention. Therefore
I redo my change. (Without it pronterface on my PC does not
display the temperature graph, the xy- and z- buttons.)
